### PR TITLE
Feature/heartbeat

### DIFF
--- a/commanderer/main.go
+++ b/commanderer/main.go
@@ -2,15 +2,21 @@ package main
 
 import (
 	"embed"
-	"net/http"
-
-	"github.com/rubenhoenle/pixelknecht/commanderer/config"
-
 	"github.com/gin-gonic/gin"
+	"github.com/rubenhoenle/pixelknecht/commanderer/config"
+	"net/http"
+	"time"
 )
 
 //go:embed static/*
 var static embed.FS
+
+const (
+	port              = ":8999"
+	heartbeatInterval = 5 * time.Second  // How often we expect heartbeats
+	readTimeout       = 10 * time.Second // Timeout for missing heartbeat
+	checkInterval     = 3 * time.Second  // Interval for checking connection
+)
 
 type floodMode struct {
 	Enabled bool `json:"enabled"`
@@ -51,6 +57,7 @@ func setupRouter() *gin.Engine {
 var mode floodMode
 
 func main() {
+	go RunTcpServer()
 	mode = floodMode{Enabled: true, PosY: 0, PosX: 0, ImageUrl: "https://s3.sfz-aalen.space/static/hackwerk/open.png"}
 	router := setupRouter()
 	router.Run(config.ReadEnvWithFallback("COMMANDERER_LISTEN_HOST", "localhost") + ":9000")

--- a/commanderer/tcpServer.go
+++ b/commanderer/tcpServer.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+)
+
+type Client struct {
+	conn         net.Conn
+	lastActivity time.Time
+}
+
+type TcpServer struct {
+	clients map[string]*Client
+	mu      sync.Mutex
+}
+
+func RunTcpServer() {
+	server := &TcpServer{clients: make(map[string]*Client)}
+
+	listener, err := net.Listen("tcp", port)
+	if err != nil {
+		fmt.Println("Error starting server:", err)
+		return
+	}
+	defer listener.Close()
+	fmt.Println("Server listening on", port)
+
+	go server.checkConnections()
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			fmt.Println("Error accepting connection:", err)
+			continue
+		}
+		server.addClient(conn)
+		client := server.clients[conn.RemoteAddr().String()]
+		go server.handleConnection(client)
+	}
+}
+
+func (s *TcpServer) addClient(conn net.Conn) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	client := &Client{conn: conn, lastActivity: time.Now()}
+	s.clients[conn.RemoteAddr().String()] = client
+	fmt.Printf("Added client %s\n", conn.RemoteAddr().String())
+}
+
+func (s *TcpServer) removeClient(client *Client) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	addr := client.conn.RemoteAddr().String()
+	client.conn.Close()
+	delete(s.clients, addr)
+	fmt.Printf("Removed client %s\n", addr)
+}
+
+func (s *TcpServer) handleConnection(client *Client) {
+	defer s.removeClient(client)
+
+	reader := bufio.NewReader(client.conn)
+	for {
+		client.conn.SetReadDeadline(time.Now().Add(readTimeout))
+
+		message, err := reader.ReadString('\n')
+		if err != nil {
+			fmt.Printf("Error from %s: %v\n", client.conn.RemoteAddr(), err)
+			return
+		}
+
+		if message == "heartbeat\n" {
+			fmt.Printf("Received heartbeat from %s\n", client.conn.RemoteAddr())
+			client.lastActivity = time.Now() // Update last activity time
+		}
+	}
+}
+
+func (s *TcpServer) checkConnections() {
+	for {
+		time.Sleep(checkInterval)
+		s.mu.Lock()
+		for addr, client := range s.clients {
+			if time.Since(client.lastActivity) > readTimeout {
+				fmt.Printf("Client %s timed out\n", addr)
+				s.removeClient(client)
+			}
+		}
+		s.mu.Unlock()
+	}
+}

--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,7 @@
           ];
           shellHook = ''
             export COMMANDERER_URL="http://localhost:9000"
+            export COMMANDERER_TCP="localhost:8999"
             alias cover-report="go test -coverprofile cover.out && go tool cover -html=cover.out -o cover.html && xdg-open cover.html"
           '';
         };

--- a/pixelknecht/main.go
+++ b/pixelknecht/main.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -30,6 +29,7 @@ func main() {
 
 	wg.Add(1)
 	go commandHandler(3)
+	go SendHeartbeat()
 
 	// wait for the goroutines to finish
 	wg.Wait()
@@ -71,19 +71,8 @@ func commandHandler(pollIntervalSec int) {
 	}
 }
 
-func ReadEnvWithFallback(key string, fallback string) string {
-	if value, ok := os.LookupEnv(key); ok {
-		return value
-	}
-	return fallback
-}
-
-func getCommandererUrl() string {
-	return ReadEnvWithFallback("COMMANDERER_URL", "http://commanderer.hoenle.xyz:9000")
-}
-
 func getModeFromCommanderer() floodMode {
-	response, err := http.Get(getCommandererUrl() + "/mode")
+	response, err := http.Get(GetCommandererUrl() + "/mode")
 	if err != nil {
 		fmt.Print(err.Error())
 		// TODO: error handling

--- a/pixelknecht/server.go
+++ b/pixelknecht/server.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"time"
+)
+
+const (
+	heartbeatInterval = 5 * time.Second
+)
+
+func readEnvWithFallback(key string, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
+}
+
+func GetCommandererUrl() string {
+	return readEnvWithFallback("COMMANDERER_URL", "http://commanderer.hoenle.xyz:9000")
+}
+
+func GetCommandererTcp() string {
+	return readEnvWithFallback("COMMANDERER_TCP", "commanderer.hoenle.xyz:8999")
+}
+
+func SendHeartbeat() {
+	conn, err := net.Dial("tcp", GetCommandererTcp())
+	if err != nil {
+		fmt.Println("Error connecting to server:", err)
+		return
+	}
+	defer conn.Close()
+	fmt.Println("Connected Commanderer to server")
+
+	ticker := time.NewTicker(heartbeatInterval)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		_, err := conn.Write([]byte("heartbeat\n"))
+		if err != nil {
+			fmt.Println("Error sending heartbeat:", err)
+			return
+		}
+		fmt.Println("Sent heartbeat") // debug
+	}
+}

--- a/pixelknecht/tcp_output.go
+++ b/pixelknecht/tcp_output.go
@@ -18,7 +18,7 @@ type pixelflutServer struct {
 const workerPoolSize = 15
 
 func getPixelflutServerStringFromCommanderer() string {
-	response, err := http.Get(getCommandererUrl() + "/api/server")
+	response, err := http.Get(GetCommandererUrl() + "/api/server")
 	if err != nil {
 		fmt.Print(err.Error())
 		// TODO: error handling


### PR DESCRIPTION
tcp connection between knecht and commanderer

TODO:
- [ ] sync with ruben about this approach
- [ ] add tests
- [ ] check if additional tcp connection in client has impact on performance to pixelserver (also tcp)

tcp connection could be used to communicate to the knechte about stats etc...
Other approach would implement upcoming features in the existing http api. But i think separating between connections to kenchte and e.g fronted (or other systems in the future like grafana) could be useful.  
